### PR TITLE
fix(ai-service): update permission handling to return JSON response o…

### DIFF
--- a/apps/ai-service/app/auth/deps.py
+++ b/apps/ai-service/app/auth/deps.py
@@ -1,3 +1,4 @@
+from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordBearer
 from fastapi import Depends, HTTPException, status
 from app.models.generated import AuthenticatedUser, AppPermission
@@ -62,8 +63,8 @@ class RequiredPermission:
         :raises HTTPException: If user lacks required permission
         """
         if self.required_permission.value not in current_user.permissions:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Missing permission: {self.required_permission.value}"
+            return JSONResponse(
+                status_code=status.HTTP_200_OK,
+                content={"message": "Permission denied", "success": False}
             )
         return current_user

--- a/apps/ai-service/tests/test_auth_deps.py
+++ b/apps/ai-service/tests/test_auth_deps.py
@@ -71,8 +71,10 @@ async def test_required_permission_rejects_without_permission():
         permissions=[],
     )
 
-    with pytest.raises(HTTPException) as exc:
-        await dep(user)
+    result = await dep(user)
 
-    assert exc.value.status_code == 403
-    assert "Missing permission" in exc.value.detail
+    assert result.status_code == 200
+    import json
+    data = json.loads(result.body)
+    assert data["message"] == "Permission denied"
+    assert data["success"] is False


### PR DESCRIPTION
This pull request makes a small but important change to the permission-checking logic in the authentication dependencies. Instead of raising an HTTP 403 error when a user lacks the required permission, the code now returns a JSON response with a 200 status code and a message indicating permission denial.

- Changed the response for missing permissions in the `PermissionChecker` to return a JSON message with status 200 and `"success": False` instead of raising a 403 HTTPException.
- Imported `JSONResponse` from `fastapi.responses` to support the new response behavior.…n denial